### PR TITLE
import reverse from django.urls in Django>=2.0

### DIFF
--- a/zinnia_markitup/__init__.py
+++ b/zinnia_markitup/__init__.py
@@ -1,5 +1,5 @@
 """MarkItUp for Django-blog-zinnia"""
-__version__ = '1.2'
+__version__ = '1.2.1'
 __license__ = 'BSD License'
 
 __author__ = 'Fantomas42'

--- a/zinnia_markitup/admin.py
+++ b/zinnia_markitup/admin.py
@@ -2,7 +2,11 @@
 from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.urlresolvers import reverse
+import django
+if django.VERSION[0] < 2:
+    from django.core.urlresolvers import reverse
+else:
+    from django.urls import reverse
 from django.forms import Media
 from django.template.response import TemplateResponse
 from django.views.decorators.csrf import csrf_exempt


### PR DESCRIPTION
Django-2 moved `reverse` to a different package and Django-2.2 removed it from the old place, which breaks zinnia-wysiwyg-markitup. This fix conditionally imports `reverse` based on Django version.